### PR TITLE
Upgrade projects to .NET 8 and improve tests

### DIFF
--- a/GameLibrary.Core.Tests.xUnit/FileServiceTests.cs
+++ b/GameLibrary.Core.Tests.xUnit/FileServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Data.Common;
+using System.IO;
 
 using GameLibrary.Core.Services;
 
@@ -38,7 +39,7 @@ public class FileServiceTests : IDisposable
         }
         else
         {
-            Assert.True(false, $"File not exist: {_filePath}");
+            Assert.Fail($"File not exist: {_filePath}");
         }
     }
 
@@ -76,9 +77,18 @@ public class FileServiceTests : IDisposable
 
     public void Dispose()
     {
-        if (File.Exists(_filePath))
-        {
-            File.Delete(_filePath);
-        }
-    }
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (disposing)
+		{
+			if (File.Exists(_filePath))
+			{
+				File.Delete(_filePath);
+			}
+		}
+	}
 }

--- a/GameLibrary.Core.Tests.xUnit/GameLibrary.Core.Tests.xUnit.csproj
+++ b/GameLibrary.Core.Tests.xUnit/GameLibrary.Core.Tests.xUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86;AnyCPU</Platforms>
     <RootNamespace>GameLibrary.Core.Tests.xUnit</RootNamespace>
@@ -21,9 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GameLibrary.Core/GameLibrary.Core.csproj
+++ b/GameLibrary.Core/GameLibrary.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/GameLibrary.Tests.xUnit/GameLibrary.Tests.xUnit.csproj
+++ b/GameLibrary.Tests.xUnit/GameLibrary.Tests.xUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssetTargetFallback>uap10.0.18362</AssetTargetFallback>
     <Platforms>x64;x86;AnyCPU</Platforms>
@@ -22,11 +22,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GameLibrary.Tests.xUnit/PagesTests.cs
+++ b/GameLibrary.Tests.xUnit/PagesTests.cs
@@ -71,7 +71,7 @@ public class PagesTests
         }
         else
         {
-            Assert.True(false, $"Can't resolve {nameof(IPageService)}");
+            Assert.Fail($"Can't resolve {nameof(IPageService)}");
         }
     }
 
@@ -93,7 +93,7 @@ public class PagesTests
         }
         else
         {
-            Assert.True(false, $"Can't resolve {nameof(IPageService)}");
+            Assert.Fail($"Can't resolve {nameof(IPageService)}");
         }
     }
 
@@ -115,7 +115,7 @@ public class PagesTests
         }
         else
         {
-            Assert.True(false, $"Can't resolve {nameof(IPageService)}");
+            Assert.Fail($"Can't resolve {nameof(IPageService)}");
         }
     }
 }

--- a/GameLibrary/GameLibrary.csproj
+++ b/GameLibrary/GameLibrary.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <RootNamespace>GameLibrary</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
-    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
- Updated `FileServiceTests.cs` to include `System.Data.Common` and changed assertions for file existence.
- Enhanced `Dispose` method for better resource management.
- Upgraded target framework for test projects to `net8.0-windows10.0.19041.0` and updated package references.
- Changed `Newtonsoft.Json` version in `GameLibrary.Core.csproj` to `13.0.3`.
- Updated assertions in `PagesTests.cs` for consistency.
- Updated `GameLibrary.csproj` to target `net8.0` and upgraded several package references.