### PR TITLE
Add database seeding and update data context for SQLite

### DIFF
--- a/src/GameLibrary.Core/Data/DbInitializer.cs
+++ b/src/GameLibrary.Core/Data/DbInitializer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GameLibrary.Core.Models;
+
+namespace GameLibrary.Core.Data;
+
+public static class DbInitializer
+{
+	public static void Initialize(GameLibraryDataContext context)
+	{
+		// Look for any students.
+		if (context.Games.Any())
+		{
+			return;   // DB has been seeded
+		}
+
+		var platforms = new Platform[]
+		{
+			new() { Id = Guid.NewGuid(), Name = "PC" },
+			new() { Id = Guid.NewGuid(), Name = "PlayStation" },
+			new() { Id = Guid.NewGuid(), Name = "Xbox" },
+			new() { Id = Guid.NewGuid(), Name = "Nintendo" },
+			new() { Id = Guid.NewGuid(), Name = "Mobile" },
+		};
+
+		context.Platforms.AddRange(platforms);
+		context.SaveChanges();
+
+		var genres = new Genre[]
+		{
+			new() { Id = Guid.NewGuid(), Name = "Action" },
+			new() { Id = Guid.NewGuid(), Name = "Adventure" },
+			new() { Id = Guid.NewGuid(), Name = "RPG" },
+			new() { Id = Guid.NewGuid(), Name = "Simulation" },
+			new() { Id = Guid.NewGuid(), Name = "Strategy" },
+		};
+
+		context.Genres.AddRange(genres);
+		context.SaveChanges();
+
+		var games = new Game[]
+		{
+			new() { Id = Guid.NewGuid(), Title = "The Witcher 3: Wild Hunt", Platform = platforms.First(x => x.Name == "PC"), Genre = genres.First(x => x.Name == "RPG"), ReleaseYear = 2015, Status = GameStatus.NotStarted },
+			new() { Id = Guid.NewGuid(), Title = "The Legend of Zelda: Breath of the Wild", Platform = platforms.First(x => x.Name == "Nintendo"), Genre = genres.First(x => x.Name == "RPG"), ReleaseYear = 2017, Status = GameStatus.NotStarted },
+			new() { Id = Guid.NewGuid(), Title = "Red Dead Redemption 2", Platform = platforms.First(x => x.Name == "PlayStation"), Genre = genres.First(x => x.Name == "Action"), ReleaseYear = 2018, Status = GameStatus.NotStarted },
+			new() { Id = Guid.NewGuid(), Title = "The Elder Scrolls V: Skyrim", Platform = platforms.First(x => x.Name == "PC"), Genre = genres.First(x => x.Name == "RPG"), ReleaseYear = 2011, Status = GameStatus.NotStarted },
+			new() { Id = Guid.NewGuid(), Title = "Grand Theft Auto V", Platform = platforms.First(x => x.Name == "PC"), Genre = genres.First(x => x.Name == "Action"), ReleaseYear = 2013, Status = GameStatus.NotStarted },
+		};
+
+		context.Games.AddRange(games);
+		context.SaveChanges();
+	}
+}

--- a/src/GameLibrary.Core/Data/GameLibraryDataContext.cs
+++ b/src/GameLibrary.Core/Data/GameLibraryDataContext.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GameLibrary.Core.Models;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace GameLibrary.Core.Data;
+
+public class GameLibraryDataContext(DbContextOptions<GameLibraryDataContext> options) : DbContext(options)
+{
+	public DbSet<Game> Games { get; set; }
+	public DbSet<Platform> Platforms { get; set; }
+	public DbSet<Genre> Genres { get; set; }
+}

--- a/src/GameLibrary.Core/GameLibrary.Core.csproj
+++ b/src/GameLibrary.Core/GameLibrary.Core.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>GameLibrary.Core</RootNamespace>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/GameLibrary.Core/Services/DataService.cs
+++ b/src/GameLibrary.Core/Services/DataService.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GameLibrary.Core.Contracts.Services;
+using GameLibrary.Core.Models;
+using GameLibrary.Core.Data;
+
+namespace GameLibrary.Core.Services;
+
+public class DataService(GameLibraryDataContext dbContext) : IDataService
+{
+	public async Task<Game> AddGameAsync(Game game)
+	{
+		var newGame = new Game
+		{
+			Id = Guid.NewGuid(),
+			Title = game.Title,
+			ReleaseYear = game.ReleaseYear,
+			Status = game.Status,
+			Genre = game.Genre,
+			Platform = game.Platform
+		};
+
+		dbContext.Games.Add(newGame);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(game);
+	}
+
+	public async Task<Genre> AddGenreAsync(Genre genre)
+	{
+		var newGenre = new Genre
+		{
+			Id = Guid.NewGuid(),
+			Name = genre.Name
+		};
+
+		dbContext.Genres.Add(newGenre);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(genre);
+	}
+
+	public async Task<Platform> AddPlatformAsync(Platform platform)
+	{
+		var newPlatform = new Platform
+		{
+			Id = Guid.NewGuid(),
+			Name = platform.Name
+		};
+
+		dbContext.Platforms.Add(newPlatform);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(platform);
+	}
+
+	public async Task DeleteGameAsync(Guid id)
+	{
+		dbContext.Games.Remove(dbContext.Games.Find(id));
+		await dbContext.SaveChangesAsync();
+	}
+
+	public async Task DeleteGenreAsync(Guid id)
+	{
+		dbContext.Genres.Remove(dbContext.Genres.Find(id));
+		await dbContext.SaveChangesAsync();
+	}
+
+	public async Task DeletePlatformAsync(Guid id)
+	{
+		dbContext.Platforms.Remove(dbContext.Platforms.Find(id));
+		await dbContext.SaveChangesAsync();
+	}
+
+	public Task<Game> GetGameAsync(Guid id)
+	{
+		var game = dbContext.Games.Find(id) ?? throw new KeyNotFoundException($"Game with Id {id} not found.");
+
+		return Task.FromResult(game);
+	}
+
+	public Task<IEnumerable<Game>> GetGamesAsync()
+	{
+		return Task.FromResult(dbContext.Games.AsEnumerable());
+	}
+
+	public Task<Genre> GetGenreAsync(Guid id)
+	{
+		var genre = dbContext.Genres.Find(id) ?? throw new KeyNotFoundException($"Genre with Id {id} not found.");
+
+		return Task.FromResult(genre);
+	}
+
+	public Task<IEnumerable<Genre>> GetGenresAsync()
+	{
+		return Task.FromResult(dbContext.Genres.AsEnumerable());
+	}
+
+	public Task<Platform> GetPlatformAsync(Guid id)
+	{
+		var platform = dbContext.Platforms.Find(id) ?? throw new KeyNotFoundException($"Platform with Id {id} not found.");
+
+		return Task.FromResult(platform);
+	}
+
+	public Task<IEnumerable<Platform>> GetPlatformsAsync()
+	{
+		return Task.FromResult(dbContext.Platforms.AsEnumerable());
+	}
+
+	public async Task<Game> UpdateGameAsync(Game game)
+	{
+		var existingGame = dbContext.Games.Find(game.Id) ?? throw new KeyNotFoundException($"Game with Id {game.Id} not found.");
+
+		existingGame.Title = game.Title;
+		existingGame.ReleaseYear = game.ReleaseYear;
+		existingGame.Status = game.Status;
+		existingGame.Genre = game.Genre;
+		existingGame.Platform = game.Platform;
+
+		var updatedGame = dbContext.Update(existingGame);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(updatedGame.Entity);
+	}
+
+	public async Task<Genre> UpdateGenreAsync(Genre genre)
+	{
+		var existingGenre = dbContext.Genres.Find(genre.Id) ?? throw new KeyNotFoundException($"Genre with Id {genre.Id} not found.");
+
+		existingGenre.Name = genre.Name;
+
+		var updatedGenre = dbContext.Update(existingGenre);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(updatedGenre.Entity);
+	}
+
+	public async Task<Platform> UpdatePlatformAsync(Platform platform)
+	{
+		var existingPlatform = dbContext.Platforms.Find(platform.Id) ?? throw new KeyNotFoundException($"Platform with Id {platform.Id} not found.");
+
+		existingPlatform.Name = platform.Name;
+		
+		var updatedPlatform = dbContext.Update(existingPlatform);
+		await dbContext.SaveChangesAsync();
+
+		return await Task.FromResult(dbContext.Update(existingPlatform).Entity);
+	}
+}

--- a/src/GameLibrary/appsettings.json
+++ b/src/GameLibrary/appsettings.json
@@ -3,5 +3,8 @@
     "configurationsFolder": "GameLibrary\\Configurations",
     "appPropertiesFileName": "AppProperties.json",
     "privacyStatement": "https://YourPrivacyUrlGoesHere/"
+  },
+  "ConnectionStrings": {
+    "GameLibraryContextSQLite": "Data Source=gameLibrary.db"
   }
 }


### PR DESCRIPTION
- Introduced `DbInitializer.cs` to seed initial data for platforms, genres, and games.
- Updated `GameLibraryDataContext.cs` to define the context class with `DbSet` properties.
- Changed target framework in `GameLibrary.Core.csproj` to `net8.0` and added SQLite package reference.
- Enhanced `DataService.cs` with async methods for CRUD operations on games, genres, and platforms.
- Modified `App.xaml.cs` to create the database at startup and seed data in debug mode.
- Updated `appsettings.json` to include a connection string for the SQLite database.